### PR TITLE
Create api for items show; postman passing (3/3)

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -4,6 +4,11 @@ class Api::V1::ItemsController < ApplicationController
     render json: ItemSerializer.new(@items)
   end
 
+  def show
+    @item = Item.find(params[:id])
+    render json: ItemSerializer.new(@item)
+  end
+
   private
 
   def set_page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :merchants, only: [:index, :show]
-      resources :items, only: :index
+      resources :items, only: [:index, :show]
     end
   end
 end

--- a/spec/api/v1/items_request_spec.rb
+++ b/spec/api/v1/items_request_spec.rb
@@ -32,4 +32,41 @@ RSpec.describe 'Items API' do
   end
 
   it 'does not have data for merchant'
+
+  it 'sends a single item' do
+    merchant = create(:merchant)
+    item1 = merchant.items.create(name: "This Thing", description: "aldjsflasjdfl.", unit_price: 10.99)
+
+    get "/api/v1/items/#{item1.id}"
+
+    item = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+
+    expect(item[:data]).to have_key(:id)
+    expect(item[:data][:id]).to be_a(String)
+
+    expect(item[:data][:attributes]).to have_key(:name)
+    expect(item[:data][:attributes][:name]).to be_a(String)
+
+    expect(item[:data][:attributes]).to have_key(:description)
+    expect(item[:data][:attributes][:description]).to be_a(String)
+
+    expect(item[:data][:attributes]).to have_key(:unit_price)
+    expect(item[:data][:attributes][:unit_price]).to be_a(Numeric)
+
+    expect(item[:data][:attributes]).to have_key(:merchant_id)
+    expect(item[:data][:attributes][:merchant_id]).to be_a(Numeric)
+  end
+
+  it 'does not have merchant info'
+
+  xit 'returns 404 message when input invalid, is this something that needs to be tested?' do
+    merchant = create(:merchant)
+    item1 = Item.create(name: "This Thing", description: "aldjsflasjdfl.", unit_price: 10.99, merchant_id: "10")
+
+    get "/api/v1/items/#{item1.id}"
+
+    expect(response.status).to eq(404)
+  end
 end


### PR DESCRIPTION
What was done:
- Create api for GET items show

Roadblocks:
- Issues with faker/factory bot not creating proper merchant id for item

Testing:
[x] Simplecov > 98%
[x] rspec tests passing
[x] postman tests passing
- unsure of how to write sad path tests; responses come up as 200 instead of 404.

Notes:
- no rubocop offenses
